### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Basic Syntax
 
-Insert this little [EJS](http://ejs.co/) snippet anywhere you want to show your hints:
+Insert this little [Nunjucks](https://github.com/mozilla/nunjucks) snippet anywhere you want to show your hints:
 
 ```js
 {% hint 'body_text' 'hint_text' %}


### PR DESCRIPTION
Hexo tag is not using EJS, but Nunjucks.

Ref:

https://github.com/hexojs/hexo/blob/35ca7bb72566afe0828f45efa9e8da3736609234/lib/extend/tag.js#L5